### PR TITLE
fix links to data description etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# pycharm
+.idea
+
 # IPython
 profile_default/
 ipython_config.py

--- a/docs/primap-hist/index.html
+++ b/docs/primap-hist/index.html
@@ -137,6 +137,7 @@ Subsector data for Energy, Industrial Processes and Agriculture is available for
 
 
 
+<a href="https://zenodo.org/api/records/10006301/files/PRIMAP-hist_v2.5_data-description.pdf/content">Data Description and Changelog (PDF)</a> |
 
 
 
@@ -182,6 +183,9 @@ Subsector data for Energy, Industrial Processes and Agriculture is available for
 
 
 
+
+
+<a href="https://zenodo.org/api/records/10006301/files/PRIMAP-hist_v2.5_updated_figures.pdf/content">Updated Figures (PDF)</a>
 
 
 
@@ -527,7 +531,7 @@ Subsector data for Energy, Industrial Processes and Agriculture is available for
 
     <p>Emissions from international Aviation and Shipping are not included.</p>
 
-    <p>Gas categories are using global warming potentials from either the IPCC's (Intergovernmental Panel on Climate Change) Second Assessment Report (SAR) or Assessment Report 4 (AR4).</p>
+    <p>Gas categories are using global warming potentials from either the IPCC's (Intergovernmental Panel on Climate Change) Second Assessment Report (SAR), Assessment Report 4 (AR4), Assessment Report 5 (AR5) or Assessment Report 6 (AR6).</p>
 
     <p>
     The last years of the time series are obtained using extrapolations for some sectors and gases for Non-Annex-I countries. Therefore these data have to be used with caution when making statements about short term emissions trends.

--- a/primap-hist/template.jinja2.html
+++ b/primap-hist/template.jinja2.html
@@ -130,11 +130,11 @@ Subsector data for Energy, Industrial Processes and Agriculture is available for
 <p>
 <a href="https://github.com/JGuetschow/PRIMAP-hist">Issue tracker on GitHub</a> |
 {% for file in data["files"] %}
-{% if 'data-description.pdf' in file["key"] %}
-<a href="{{ file['links']['self'] }}">Data Description and Changelog (PDF)</a> |
+{% if 'data-description.pdf' in file["filename"] %}
+<a href="{{ file['links']['download'] }}">Data Description and Changelog (PDF)</a> |
 {% endif %}
-{% if 'updated_figures.pdf' in file["key"] %}
-<a href="{{ file['links']['self'] }}">Updated Figures (PDF)</a>
+{% if 'updated_figures.pdf' in file["filename"] %}
+<a href="{{ file['links']['download'] }}">Updated Figures (PDF)</a>
 {% endif %}
 {% endfor%}
 </p>


### PR DESCRIPTION
Links to data description and updates figures were broken because of a change in metadata on zenodo. This is fixed now